### PR TITLE
Add LinearCombinationEstimator to estimation module

### DIFF
--- a/pyrake/estimation/__init__.py
+++ b/pyrake/estimation/__init__.py
@@ -1,6 +1,7 @@
 """Estimation utilities."""
 
 from .base_classes import Estimand, SimpleEstimand, WeightingEstimator
+from .linear_combination import LinearCombinationEstimator
 from .population import (
     AIPWEstimator,
     IPWEstimator,
@@ -31,6 +32,7 @@ __all__ = [
     "DoubleSamplingEstimand",
     "Estimand",
     "IPWEstimator",
+    "LinearCombinationEstimator",
     "MeanEstimator",
     "NonRespondentMean",
     "PopulationMean",

--- a/pyrake/estimation/base_classes.py
+++ b/pyrake/estimation/base_classes.py
@@ -2,6 +2,7 @@
 
 import math
 from abc import ABC, abstractmethod, abstractproperty
+from collections.abc import Generator
 from typing import Literal, Self
 
 import matplotlib.pyplot as plt
@@ -123,6 +124,29 @@ class WeightingEstimator(ABC):
          - Fogarty, Colin. 2023. "Sensitivity Analysis." In Handbook of Matching and
            Weighting Adjustments for Causal Inference, , pg. 553--82. Chapman and
            Hall/CRC.
+
+        """
+
+    @abstractmethod
+    def resample(
+        self,
+        B: int,
+        seed: None | (
+            int
+            | list[int]
+            | np.random.SeedSequence
+            | np.random.BitGenerator
+            | np.random.Generator
+        ) = None,
+    ) -> Generator["WeightingEstimator", None, None]:
+        """Yield a sequence of B bootstrap-resampled estimators.
+
+        Parameters
+        ----------
+         B : int
+            Number of bootstrap replications.
+         seed : int, list_like, etc
+            A seed for numpy.random.default_rng.
 
         """
 

--- a/pyrake/estimation/linear_combination.py
+++ b/pyrake/estimation/linear_combination.py
@@ -1,0 +1,213 @@
+"""Linear combination estimator."""
+
+from collections.abc import Generator
+from typing import Literal
+
+import numpy as np
+
+from .base_classes import WeightingEstimator
+
+
+class LinearCombinationEstimator(WeightingEstimator):
+    r"""Affine combination of WeightingEstimators.
+
+    Estimates:
+
+        theta = affine + sum_i c_i * theta_i
+
+    where each theta_i is estimated by the corresponding component estimator.
+    Component estimators may be MeanEstimators, TreatmentEffectEstimators, or
+    other LinearCombinationEstimators.
+
+    Sensitivity analysis is valid because the objective is separable across
+    components: hidden bias in each component contributes independently, and
+    the worst-case bounds combine linearly (with sign-aware bound selection).
+
+    Parameters
+    ----------
+     terms : list of (float, WeightingEstimator) pairs
+        Coefficients and their associated estimators.
+     affine : float, optional
+        Constant offset. Defaults to 0.0.
+
+    Notes
+    -----
+    Variance is computed assuming independence across component estimators:
+
+        var(theta) = sum_i c_i^2 * var(theta_i).
+
+    This is exact when components are fit on disjoint datasets (e.g. different
+    treatment arms or independent studies). If components share data, variance
+    will be understated and variance-based methods (confidence_interval,
+    pvalue) will be anti-conservative. Bootstrap-based methods
+    (expanded_confidence_interval) carry the same independence assumption
+    since each component is resampled independently.
+
+    """
+
+    def __init__(
+        self,
+        terms: list[tuple[float, WeightingEstimator]],
+        affine: float = 0.0,
+    ) -> None:
+        self.terms = terms
+        self.affine = affine
+
+    def point_estimate(self) -> float:
+        """Calculate the point estimate."""
+        return self.affine + sum(c * e.point_estimate() for c, e in self.terms)
+
+    def variance(self) -> float:
+        """Calculate the variance.
+
+        Assumes independence across component estimators. See class docstring.
+
+        """
+        return sum(c**2 * e.variance() for c, e in self.terms)
+
+    def sensitivity_analysis(self, gamma: float = 6.0) -> tuple[float, float]:
+        r"""Perform a sensitivity analysis.
+
+        The analysis is separable across components. For coefficient c and
+        component sensitivity interval [lb_i, ub_i]:
+
+          - c >= 0: contributes c * lb_i to the overall lower bound and
+            c * ub_i to the overall upper bound.
+          - c < 0: contributes c * ub_i to the overall lower bound and
+            c * lb_i to the overall upper bound.
+
+        The affine term shifts both bounds by the same constant.
+
+        Parameters
+        ----------
+         gamma : float, optional
+            The Gamma factor. Must be >= 1.0, with 1.0 indicating perfect
+            propensity scores. Defaults to 6. See WeightingEstimator.
+
+        Returns
+        -------
+         lb, ub : float
+            Lower and upper bounds on the point estimate.
+
+        """
+        lb = self.affine
+        ub = self.affine
+        for c, e in self.terms:
+            e_lb, e_ub = e.sensitivity_analysis(gamma)
+            if c >= 0:
+                lb += c * e_lb
+                ub += c * e_ub
+            else:
+                lb += c * e_ub
+                ub += c * e_lb
+        return lb, ub
+
+    def resample(
+        self,
+        B: int,
+        seed: None | (
+            int
+            | list[int]
+            | np.random.SeedSequence
+            | np.random.BitGenerator
+            | np.random.Generator
+        ) = None,
+    ) -> Generator["LinearCombinationEstimator", None, None]:
+        """Yield a sequence of resampled estimators.
+
+        Each of the B bootstrap iterations yields a new
+        LinearCombinationEstimator whose components are independently
+        resampled from their respective component estimators.
+
+        Parameters
+        ----------
+         B : int
+            Number of bootstrap replications.
+         seed : int, list_like, etc
+            A seed for numpy.random.default_rng. See that documentation.
+
+        """
+        if not self.terms:
+            # No stochastic components; yield B identical copies so that
+            # this estimator composes correctly inside another LCE.
+            for _ in range(B):
+                yield LinearCombinationEstimator(terms=[], affine=self.affine)
+            return
+
+        resamplers = [e.resample(B, seed=seed) for _, e in self.terms]
+        for resampled_components in zip(*resamplers, strict=False):
+            yield LinearCombinationEstimator(
+                terms=[
+                    (c, est)
+                    for (c, _), est in zip(
+                        self.terms, resampled_components, strict=False
+                    )
+                ],
+                affine=self.affine,
+            )
+
+    def expanded_confidence_interval(
+        self,
+        alpha: float = 0.10,
+        gamma: float = 6.0,
+        alternative: Literal["two-sided", "less", "greater"] = "two-sided",
+        B: int = 1_000,
+        seed: None | (
+            int
+            | list[int]
+            | np.random.SeedSequence
+            | np.random.BitGenerator
+            | np.random.Generator
+        ) = None,
+    ) -> tuple[float, float]:
+        r"""Calculate an expanded confidence interval.
+
+        For each bootstrap replicate, the sensitivity interval is computed for
+        the resampled linear combination (itself using the separability
+        property), and then percentiles of those bootstrap sensitivity bounds
+        are returned as the expanded confidence interval.
+
+        Parameters
+        ----------
+         alpha : float, optional
+            P-value threshold. Defaults to 0.10 (90% interval).
+         gamma : float, optional
+            The Gamma factor. Must be >= 1.0. Defaults to 6.
+         alternative : ["two-sided", "less", "greater"], optional
+            Defaults to "two-sided".
+         B : int, optional
+            Number of bootstrap replications. Defaults to 1_000.
+         seed : int, list_like, etc
+            A seed for numpy.random.default_rng.
+
+        Returns
+        -------
+         lb, ub : float
+            Lower and upper bounds on the confidence interval. For one-sided
+            intervals, only one of these will be finite.
+
+        """
+        if gamma < 1.0:
+            raise ValueError("`gamma` must be >= 1")
+
+        if gamma == 1.0 or not self.terms:
+            return self.confidence_interval(alpha=alpha, alternative=alternative)
+
+        lb_bootstrap = np.zeros(B)
+        ub_bootstrap = np.zeros(B)
+        for b, lce in enumerate(self.resample(B, seed)):
+            lb_bootstrap[b], ub_bootstrap[b] = lce.sensitivity_analysis(gamma=gamma)
+
+        if alternative == "two-sided":
+            lb = float(np.percentile(lb_bootstrap, 100 * alpha / 2))
+            ub = float(np.percentile(ub_bootstrap, 100 * (1 - alpha / 2)))
+        elif alternative == "less":
+            lb = -np.inf
+            ub = float(np.percentile(ub_bootstrap, 100 * (1 - alpha)))
+        elif alternative == "greater":
+            lb = float(np.percentile(lb_bootstrap, 100 * alpha))
+            ub = np.inf
+        else:
+            raise ValueError(f"Unrecognized input {alternative=:}")
+
+        return lb, ub

--- a/pyrake/estimation/treatment_effects.py
+++ b/pyrake/estimation/treatment_effects.py
@@ -1,7 +1,7 @@
 """Treatment effect estimators."""
 
 from collections.abc import Generator
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -185,7 +185,7 @@ class TreatmentEffectEstimator(WeightingEstimator):
             | np.random.BitGenerator
             | np.random.Generator
         ) = None,
-    ) -> Generator[tuple[WeightingEstimator, WeightingEstimator], None, None]:
+    ) -> Generator["TreatmentEffectEstimator", None, None]:
         """Yield a sequence of resampled estimators.
 
         Parameters
@@ -196,11 +196,15 @@ class TreatmentEffectEstimator(WeightingEstimator):
             A seed for numpy.random.default_rng. See that documentation for details.
 
         """
-        yield from zip(
+        for control_est, treated_est in zip(
             self.control_estimator.resample(B, seed=seed),
             self.treated_estimator.resample(B, seed=seed),
             strict=False,
-        )
+        ):
+            yield TreatmentEffectEstimator(
+                control_estimator=cast("MeanEstimator | RatioEstimator", control_est),
+                treated_estimator=cast("MeanEstimator | RatioEstimator", treated_est),
+            )
 
     def expanded_confidence_interval(
         self,
@@ -270,14 +274,8 @@ class TreatmentEffectEstimator(WeightingEstimator):
 
         lb_bootstrap = np.zeros(B)
         ub_bootstrap = np.zeros(B)
-        for b, (control_estimator, treated_estimator) in enumerate(
-            self.resample(B, seed)
-        ):
-            # Calculate sensitivity interval for this bootstrap sample
-            control_lb, control_ub = control_estimator.sensitivity_analysis(gamma=gamma)
-            treated_lb, treated_ub = treated_estimator.sensitivity_analysis(gamma=gamma)
-            lb_bootstrap[b] = treated_lb - control_ub
-            ub_bootstrap[b] = treated_ub - control_lb
+        for b, te_est in enumerate(self.resample(B, seed)):
+            lb_bootstrap[b], ub_bootstrap[b] = te_est.sensitivity_analysis(gamma=gamma)
 
         # Calculate the expanded confidence interval as percentiles of the bootstrap estimates
         if alternative == "two-sided":
@@ -1146,6 +1144,22 @@ class TreatmentEffectRatioEstimator(WeightingEstimator):
         """Not implemented."""
         raise NotImplementedError(
             "Sensitivity analysis is not implemented for TreatmentEffectRatioEstimator."
+        )
+
+    def resample(
+        self,
+        B: int,
+        seed: None | (
+            int
+            | list[int]
+            | np.random.SeedSequence
+            | np.random.BitGenerator
+            | np.random.Generator
+        ) = None,
+    ) -> Generator["TreatmentEffectRatioEstimator", None, None]:
+        """Not implemented."""
+        raise NotImplementedError(
+            "resample is not implemented for TreatmentEffectRatioEstimator."
         )
 
     def expanded_confidence_interval(

--- a/test/estimation/test_linear_combination.py
+++ b/test/estimation/test_linear_combination.py
@@ -1,0 +1,265 @@
+"""Test LinearCombinationEstimator."""
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from pyrake.estimation.linear_combination import LinearCombinationEstimator
+from pyrake.estimation.population import SIPWEstimator
+from pyrake.estimation.treatment_effects import TreatmentEffectEstimator
+
+
+def make_estimator(
+    n: int = 500,
+    seed: int = 0,
+) -> tuple[SIPWEstimator, npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+    """Return a SIPWEstimator together with the raw propensities and outcomes."""
+    rng = np.random.default_rng(seed)
+    propensities = rng.beta(2, 5, size=n)
+    outcomes = rng.normal(0.5, 1.0, size=n)
+    return SIPWEstimator(propensities, outcomes), propensities, outcomes
+
+
+class TestLinearCombinationEstimator:
+    @staticmethod
+    def test_point_estimate_basic() -> None:
+        """Affine + weighted sum equals manual computation."""
+        est1, _, _ = make_estimator(n=400, seed=1)
+        est2, _, _ = make_estimator(n=300, seed=2)
+        c1, c2, affine = 2.0, -0.5, 0.1
+
+        lce = LinearCombinationEstimator(terms=[(c1, est1), (c2, est2)], affine=affine)
+
+        expected = affine + c1 * est1.point_estimate() + c2 * est2.point_estimate()
+        assert lce.point_estimate() == pytest.approx(expected)
+
+    @staticmethod
+    def test_point_estimate_affine_only() -> None:
+        """A LinearCombinationEstimator with no terms returns the affine value."""
+        lce = LinearCombinationEstimator(terms=[], affine=0.42)
+        assert lce.point_estimate() == pytest.approx(0.42)
+
+    @staticmethod
+    def test_variance_independence() -> None:
+        """Variance equals sum of c_i^2 * var_i (independence assumption)."""
+        est1, _, _ = make_estimator(n=400, seed=1)
+        est2, _, _ = make_estimator(n=300, seed=2)
+        c1, c2 = 3.0, -1.5
+
+        lce = LinearCombinationEstimator(terms=[(c1, est1), (c2, est2)])
+
+        expected = c1**2 * est1.variance() + c2**2 * est2.variance()
+        assert lce.variance() == pytest.approx(expected)
+
+    @staticmethod
+    def test_variance_affine_only() -> None:
+        """Affine-only estimator has zero variance."""
+        lce = LinearCombinationEstimator(terms=[], affine=1.0)
+        assert lce.variance() == pytest.approx(0.0)
+
+    @staticmethod
+    def test_sensitivity_analysis_positive_coefficients() -> None:
+        """Positive coefficient: lb uses component lb, ub uses component ub."""
+        est, _, _ = make_estimator(n=500, seed=3)
+        c = 2.0
+        lce = LinearCombinationEstimator(terms=[(c, est)])
+
+        e_lb, e_ub = est.sensitivity_analysis(gamma=2.0)
+        lb, ub = lce.sensitivity_analysis(gamma=2.0)
+
+        assert lb == pytest.approx(c * e_lb)
+        assert ub == pytest.approx(c * e_ub)
+        assert lb <= ub
+
+    @staticmethod
+    def test_sensitivity_analysis_negative_coefficient() -> None:
+        """Negative coefficient flips which component bound feeds which output bound."""
+        est, _, _ = make_estimator(n=500, seed=3)
+        c = -2.0
+        lce = LinearCombinationEstimator(terms=[(c, est)])
+
+        e_lb, e_ub = est.sensitivity_analysis(gamma=2.0)
+        lb, ub = lce.sensitivity_analysis(gamma=2.0)
+
+        # c < 0: lb = c * e_ub, ub = c * e_lb
+        assert lb == pytest.approx(c * e_ub)
+        assert ub == pytest.approx(c * e_lb)
+        assert lb <= ub
+
+    @staticmethod
+    def test_sensitivity_analysis_affine_shifts_both_bounds() -> None:
+        """Affine term shifts both bounds by the same constant."""
+        est, _, _ = make_estimator(n=500, seed=4)
+        offset = 0.25
+
+        lce_base = LinearCombinationEstimator(terms=[(1.0, est)])
+        lce_shifted = LinearCombinationEstimator(terms=[(1.0, est)], affine=offset)
+
+        lb_base, ub_base = lce_base.sensitivity_analysis(gamma=3.0)
+        lb_shifted, ub_shifted = lce_shifted.sensitivity_analysis(gamma=3.0)
+
+        assert lb_shifted == pytest.approx(lb_base + offset)
+        assert ub_shifted == pytest.approx(ub_base + offset)
+
+    @staticmethod
+    def test_sensitivity_analysis_mixed_signs() -> None:
+        """Mixed-sign coefficients combine correctly."""
+        est1, _, _ = make_estimator(n=400, seed=5)
+        est2, _, _ = make_estimator(n=300, seed=6)
+        c1, c2 = 1.5, -0.8
+
+        lce = LinearCombinationEstimator(terms=[(c1, est1), (c2, est2)], affine=0.05)
+
+        lb1, ub1 = est1.sensitivity_analysis(gamma=2.0)
+        lb2, ub2 = est2.sensitivity_analysis(gamma=2.0)
+        lb, ub = lce.sensitivity_analysis(gamma=2.0)
+
+        # c1 >= 0: uses lb1 / ub1 normally
+        # c2 < 0: flips lb2 / ub2
+        assert lb == pytest.approx(0.05 + c1 * lb1 + c2 * ub2)
+        assert ub == pytest.approx(0.05 + c1 * ub1 + c2 * lb2)
+        assert lb <= ub
+
+    @staticmethod
+    def test_reduces_to_treatment_effect_estimator() -> None:
+        """LCE with coefficients (1, -1) is equivalent to TreatmentEffectEstimator."""
+        est_control, _, _ = make_estimator(n=400, seed=7)
+        est_treated, _, _ = make_estimator(n=300, seed=8)
+
+        te = TreatmentEffectEstimator(
+            control_estimator=est_control,
+            treated_estimator=est_treated,
+        )
+        lce = LinearCombinationEstimator(
+            terms=[(1.0, est_treated), (-1.0, est_control)]
+        )
+
+        assert lce.point_estimate() == pytest.approx(te.point_estimate())
+        assert lce.variance() == pytest.approx(te.variance())
+
+        te_lb, te_ub = te.sensitivity_analysis(gamma=3.0)
+        lce_lb, lce_ub = lce.sensitivity_analysis(gamma=3.0)
+        assert lce_lb == pytest.approx(te_lb)
+        assert lce_ub == pytest.approx(te_ub)
+
+    @staticmethod
+    def test_nested_linear_combination() -> None:
+        """LCE whose components include another LCE."""
+        est1, _, _ = make_estimator(n=300, seed=9)
+        est2, _, _ = make_estimator(n=300, seed=10)
+        est3, _, _ = make_estimator(n=300, seed=11)
+
+        inner = LinearCombinationEstimator(
+            terms=[(1.0, est1), (-1.0, est2)], affine=0.1
+        )
+        outer = LinearCombinationEstimator(terms=[(0.5, inner), (1.0, est3)])
+
+        expected_pe = (
+            0.5 * (0.1 + est1.point_estimate() - est2.point_estimate())
+            + est3.point_estimate()
+        )
+        assert outer.point_estimate() == pytest.approx(expected_pe)
+
+        # Sensitivity analysis should propagate through the nesting
+        inner_lb, inner_ub = inner.sensitivity_analysis(gamma=2.0)
+        est3_lb, est3_ub = est3.sensitivity_analysis(gamma=2.0)
+        outer_lb, outer_ub = outer.sensitivity_analysis(gamma=2.0)
+
+        assert outer_lb == pytest.approx(0.5 * inner_lb + est3_lb)
+        assert outer_ub == pytest.approx(0.5 * inner_ub + est3_ub)
+
+    @staticmethod
+    def test_with_treatment_effect_component() -> None:
+        """LCE can take a TreatmentEffectEstimator as a component."""
+        est_control, _, _ = make_estimator(n=400, seed=12)
+        est_treated, _, _ = make_estimator(n=400, seed=13)
+        est_baseline, _, _ = make_estimator(n=400, seed=14)
+
+        te = TreatmentEffectEstimator(
+            control_estimator=est_control,
+            treated_estimator=est_treated,
+        )
+        lce = LinearCombinationEstimator(
+            terms=[(1.0, te), (-0.1, est_baseline)],
+            affine=0.0,
+        )
+
+        expected_pe = te.point_estimate() - 0.1 * est_baseline.point_estimate()
+        assert lce.point_estimate() == pytest.approx(expected_pe)
+
+        te_lb, te_ub = te.sensitivity_analysis(gamma=2.0)
+        bl_lb, bl_ub = est_baseline.sensitivity_analysis(gamma=2.0)
+        lce_lb, lce_ub = lce.sensitivity_analysis(gamma=2.0)
+
+        # coeff on te is +1 (positive), coeff on est_baseline is -0.1 (negative)
+        assert lce_lb == pytest.approx(te_lb + (-0.1) * bl_ub)
+        assert lce_ub == pytest.approx(te_ub + (-0.1) * bl_lb)
+
+    @staticmethod
+    def test_expanded_confidence_interval_two_sided() -> None:
+        """ECI is wider than the standard CI and has lb <= pe <= ub (smoke test)."""
+        est1, _, _ = make_estimator(n=400, seed=15)
+        est2, _, _ = make_estimator(n=400, seed=16)
+        lce = LinearCombinationEstimator(terms=[(1.0, est1), (-1.0, est2)])
+
+        ci_lb, ci_ub = lce.confidence_interval(alpha=0.10)
+        eci_lb, eci_ub = lce.expanded_confidence_interval(
+            alpha=0.10, gamma=2.0, B=200, seed=42
+        )
+
+        assert eci_lb <= ci_lb + 1e-6
+        assert eci_ub >= ci_ub - 1e-6
+        assert eci_lb < eci_ub
+
+    @staticmethod
+    def test_expanded_confidence_interval_gamma_1() -> None:
+        """gamma=1 ECI falls back to the standard CI."""
+        est, _, _ = make_estimator(n=400, seed=17)
+        lce = LinearCombinationEstimator(terms=[(1.0, est)])
+
+        ci = lce.confidence_interval(alpha=0.10)
+        eci = lce.expanded_confidence_interval(alpha=0.10, gamma=1.0, B=200, seed=0)
+
+        assert eci[0] == pytest.approx(ci[0])
+        assert eci[1] == pytest.approx(ci[1])
+
+    @staticmethod
+    def test_expanded_confidence_interval_no_terms() -> None:
+        """ECI for affine-only LCE returns a degenerate interval (no uncertainty)."""
+        lce = LinearCombinationEstimator(terms=[], affine=0.5)
+        eci_lb, eci_ub = lce.expanded_confidence_interval(
+            alpha=0.10, gamma=3.0, B=100, seed=0
+        )
+        # Variance is zero, so CI and ECI both collapse to (0.5, 0.5)
+        assert eci_lb == pytest.approx(0.5)
+        assert eci_ub == pytest.approx(0.5)
+
+    @staticmethod
+    def test_expanded_confidence_interval_with_te_component() -> None:
+        """ECI works when a component is a TreatmentEffectEstimator (smoke test)."""
+        est_control, _, _ = make_estimator(n=300, seed=18)
+        est_treated, _, _ = make_estimator(n=300, seed=19)
+        te = TreatmentEffectEstimator(
+            control_estimator=est_control,
+            treated_estimator=est_treated,
+        )
+        lce = LinearCombinationEstimator(terms=[(1.0, te)])
+        lb, ub = lce.expanded_confidence_interval(alpha=0.10, gamma=2.0, B=100, seed=42)
+        assert lb < ub
+
+    @staticmethod
+    def test_expanded_confidence_interval_nested() -> None:
+        """ECI works for a nested LinearCombinationEstimator (smoke test)."""
+        est1, _, _ = make_estimator(n=300, seed=20)
+        est2, _, _ = make_estimator(n=300, seed=21)
+        est3, _, _ = make_estimator(n=300, seed=22)
+
+        inner = LinearCombinationEstimator(terms=[(1.0, est1), (-1.0, est2)])
+        outer = LinearCombinationEstimator(
+            terms=[(0.5, inner), (1.0, est3)], affine=0.1
+        )
+
+        lb, ub = outer.expanded_confidence_interval(
+            alpha=0.10, gamma=2.0, B=100, seed=42
+        )
+        assert lb < ub


### PR DESCRIPTION
Estimates theta = affine + sum_i c_i * theta_i for arbitrary
WeightingEstimator components. Sensitivity analysis is separable:
positive coefficients propagate lower/upper bounds directly, negative
coefficients flip them. Expanded confidence intervals bootstrap each
component independently and apply the same separability.

Also refactors TreatmentEffectEstimator.resample to yield
TreatmentEffectEstimator instances (rather than (control, treated)
pairs), making resample consistent across all WeightingEstimator
subclasses and enabling TreatmentEffectEstimator to be used as a
component inside LinearCombinationEstimator.

Adds resample as an abstract method on WeightingEstimator.

https://claude.ai/code/session_01PDvWG7peNpCwgNq9d3cmY4