### PR TITLE
Add Gamma parameter to meta_analysis for sensitivity analysis

### DIFF
--- a/pyrake/estimation/base_classes.py
+++ b/pyrake/estimation/base_classes.py
@@ -313,6 +313,7 @@ class WeightingEstimator(ABC):
         null_value: float,
         gamma: float = 6.0,
         alternative: Literal["two-sided", "less", "greater"] = "two-sided",
+        bootstrap: bool = True,
         B: int = 1_000,
         seed: None | (
             int
@@ -322,7 +323,7 @@ class WeightingEstimator(ABC):
             | np.random.Generator
         ) = None,
     ) -> float:
-        r"""Calculate a p-value adjusted for hidden bias via the percentile bootstrap.
+        r"""Calculate a p-value adjusted for hidden bias.
 
         The adjusted p-value accounts for both sampling uncertainty and
         uncertainty from propensity scores estimated with error. It is the
@@ -343,10 +344,19 @@ class WeightingEstimator(ABC):
               - "greater": H0: theta <= `null_value` vs Halt: theta > `null_value`.
               - "less": H0: theta >= `null_value` vs Halt: theta < `null_value`.
             Defaults to "two-sided".
+         bootstrap : bool, optional
+            If True (default), use the percentile bootstrap to account for
+            sampling variability in the sensitivity bounds. If False, use the
+            normal approximation: the adjusted p-value is computed from the
+            sensitivity interval bounds expanded by the standard error, analogous
+            to how `pvalue` uses the normal approximation. The fast path requires
+            no replications and is exact in the same sense as `pvalue`.
          B : int, optional
-            Number of bootstrap replications to run. Defaults to 1_000.
+            Number of bootstrap replications to run. Ignored when
+            ``bootstrap=False``. Defaults to 1_000.
          seed : int, list_like, etc
-            A seed for numpy.random.default_rng. See that documentation for details.
+            A seed for numpy.random.default_rng. Ignored when
+            ``bootstrap=False``. See that documentation for details.
 
         Returns
         -------
@@ -355,10 +365,11 @@ class WeightingEstimator(ABC):
 
         Notes
         -----
-        B bootstrap replicates are drawn. For each replicate, `sensitivity_analysis`
-        computes the range of point estimates consistent with gamma-level hidden bias.
-        The adjusted p-value is then the fraction of bootstrap replicates whose
-        sensitivity interval does not rule out `null_value`:
+        When ``bootstrap=True``, B bootstrap replicates are drawn. For each
+        replicate, `sensitivity_analysis` computes the range of point estimates
+        consistent with gamma-level hidden bias. The adjusted p-value is then
+        the fraction of bootstrap replicates whose sensitivity interval does not
+        rule out `null_value`:
 
           - "greater": fraction of bootstrap lower bounds that do not exceed
             `null_value`, i.e. mean(lb_bootstrap <= null_value).
@@ -366,6 +377,10 @@ class WeightingEstimator(ABC):
             `null_value`, i.e. mean(ub_bootstrap > null_value).
           - "two-sided": twice the minimum of the two one-sided adjusted
             p-values, capped at 1.
+
+        When ``bootstrap=False``, the normal approximation is used instead:
+        the sensitivity bounds replace the point estimate when computing the
+        test statistic, with the standard error computed from `variance`.
 
         When gamma=1 the sensitivity interval collapses to the point estimate,
         and the adjusted p-value reduces to the standard p-value.
@@ -383,6 +398,25 @@ class WeightingEstimator(ABC):
 
         if gamma == 1.0:
             return self.pvalue(null_value=null_value, alternative=alternative)
+
+        if not bootstrap:
+            se = math.sqrt(self.variance())
+            sen_lb, sen_ub = self.sensitivity_analysis(gamma=gamma)
+
+            if alternative == "greater" or alternative == "two-sided":
+                p_greater = float(stats.norm.sf((sen_lb - null_value) / se))
+                if alternative == "greater":
+                    return p_greater
+
+            if alternative == "less" or alternative == "two-sided":
+                p_less = float(stats.norm.sf((null_value - sen_ub) / se))
+                if alternative == "less":
+                    return p_less
+
+            if alternative == "two-sided":
+                return min(1.0, 2.0 * min(p_greater, p_less))
+
+            raise ValueError(f"Unrecognized input {alternative=:}")
 
         lb_bootstrap = np.zeros(B)
         ub_bootstrap = np.zeros(B)

--- a/pyrake/estimation/linear_combination.py
+++ b/pyrake/estimation/linear_combination.py
@@ -151,6 +151,7 @@ class LinearCombinationEstimator(WeightingEstimator):
         null_value: float,
         gamma: float = 6.0,
         alternative: Literal["two-sided", "less", "greater"] = "two-sided",
+        bootstrap: bool = True,
         B: int = 1_000,
         seed: None | (
             int
@@ -160,7 +161,7 @@ class LinearCombinationEstimator(WeightingEstimator):
             | np.random.Generator
         ) = None,
     ) -> float:
-        r"""Calculate a p-value adjusted for hidden bias via the percentile bootstrap.
+        r"""Calculate a p-value adjusted for hidden bias.
 
         See `WeightingEstimator.adjusted_pvalue` for full documentation.
 
@@ -180,6 +181,7 @@ class LinearCombinationEstimator(WeightingEstimator):
             null_value=null_value,
             gamma=gamma,
             alternative=alternative,
+            bootstrap=bootstrap,
             B=B,
             seed=seed,
         )

--- a/pyrake/estimation/treatment_effects.py
+++ b/pyrake/estimation/treatment_effects.py
@@ -117,6 +117,7 @@ class TreatmentEffectEstimator(WeightingEstimator):
         null_value: float = 0.0,
         gamma: float = 6.0,
         alternative: Literal["two-sided", "less", "greater"] = "two-sided",
+        bootstrap: bool = True,
         B: int = 1_000,
         seed: None | (
             int
@@ -126,7 +127,7 @@ class TreatmentEffectEstimator(WeightingEstimator):
             | np.random.Generator
         ) = None,
     ) -> float:
-        r"""Calculate a p-value adjusted for hidden bias via the percentile bootstrap.
+        r"""Calculate a p-value adjusted for hidden bias.
 
         See `WeightingEstimator.adjusted_pvalue` for full documentation.
 
@@ -138,10 +139,14 @@ class TreatmentEffectEstimator(WeightingEstimator):
             The Gamma factor. Must be >= 1.0. Defaults to 6.
          alternative : ["two-sided", "less", "greater"], optional
             Defaults to "two-sided".
+         bootstrap : bool, optional
+            If True (default), use the percentile bootstrap. If False, use
+            the normal approximation (no resampling).
          B : int, optional
-            Number of bootstrap replications. Defaults to 1_000.
+            Number of bootstrap replications. Ignored when ``bootstrap=False``.
+            Defaults to 1_000.
          seed : int, list_like, etc
-            A seed for numpy.random.default_rng.
+            A seed for numpy.random.default_rng. Ignored when ``bootstrap=False``.
 
         Returns
         -------
@@ -153,6 +158,7 @@ class TreatmentEffectEstimator(WeightingEstimator):
             null_value=null_value,
             gamma=gamma,
             alternative=alternative,
+            bootstrap=bootstrap,
             B=B,
             seed=seed,
         )

--- a/pyrake/estimation/visualizations.py
+++ b/pyrake/estimation/visualizations.py
@@ -19,6 +19,7 @@ def meta_analysis(
     null_max: float,
     num_points: int = 1_000,
     alpha: float = 0.10,
+    gamma: float = 1.0,
     title: str | None = None,
     xlabel: str | None = None,
     xtick_format: str = ".0%",
@@ -41,6 +42,11 @@ def meta_analysis(
          Number of hypotheses to check. Defaults to 1_000.
      alpha : float, optional
          Threshold for statistical significance. Defaults to 0.10.
+     gamma : float, optional
+         The Gamma factor for sensitivity analysis. Must be >= 1.0, with 1.0
+         indicating no hidden bias adjustment. When gamma > 1, uses
+         ``adjusted_pvalue`` (normal approximation) instead of ``pvalue``.
+         Defaults to 1.0.
      title : str, optional
          Optional title for figure.
      xlabel : str, optional
@@ -66,12 +72,28 @@ def meta_analysis(
 
     """
     null_values = np.linspace(null_min, null_max, num_points)
+
+    def _pval(
+        estimator: WeightingEstimator,
+        null_value: float,
+        alternative: "Literal['less', 'greater']",
+    ) -> float:
+        if gamma > 1.0:
+            return estimator.adjusted_pvalue(
+                null_value=null_value,
+                gamma=gamma,
+                alternative=alternative,
+                bootstrap=False,
+            )
+        return estimator.pvalue(null_value=null_value, alternative=alternative)
+
     pvals = {
         f"{platform} ({alternative})": np.array(
             [
-                estimator.pvalue(
-                    null_value=null_value,
-                    alternative=cast("Literal['less', 'greater']", alternative),
+                _pval(
+                    estimator,
+                    null_value,
+                    cast("Literal['less', 'greater']", alternative),
                 )
                 for null_value in null_values
             ]


### PR DESCRIPTION
- Add `gamma: float = 1.0` parameter to `meta_analysis` in
  `visualizations.py`. When gamma > 1, uses `adjusted_pvalue` with
  `bootstrap=False` instead of `pvalue`.
- Add `bootstrap: bool = True` parameter to `adjusted_pvalue` in
  `base_classes.py`. When `bootstrap=False`, uses the normal
  approximation (sensitivity bounds ± z * se) instead of the
  percentile bootstrap, mirroring `expanded_confidence_interval`.

https://claude.ai/code/session_01QCMYnc3sscL7n2VbZGA9Tv