### PR TITLE
Add outcome proxy constraint to sensitivity analysis

### DIFF
--- a/pyrake/estimation/base_classes.py
+++ b/pyrake/estimation/base_classes.py
@@ -98,7 +98,13 @@ class WeightingEstimator(ABC):
         return v, v
 
     @abstractmethod
-    def sensitivity_analysis(self, gamma: float = 6.0) -> tuple[float, float]:
+    def sensitivity_analysis(
+        self,
+        gamma: float = 6.0,
+        outcome_proxies: list[float] | npt.NDArray[np.float64] | None = None,
+        proxy_mean: float | None = None,
+        alpha: float = 0.10,
+    ) -> tuple[float, float]:
         r"""Perform a sensitivity analysis.
 
         Calculate a range of point estimates implied by the Gamma factor.

--- a/pyrake/estimation/linear_combination.py
+++ b/pyrake/estimation/linear_combination.py
@@ -4,6 +4,7 @@ from collections.abc import Generator
 from typing import Literal
 
 import numpy as np
+import numpy.typing as npt
 
 from .base_classes import WeightingEstimator
 
@@ -84,7 +85,13 @@ class LinearCombinationEstimator(WeightingEstimator):
                 ub_var += c**2 * e_lb_var
         return lb_var, ub_var
 
-    def sensitivity_analysis(self, gamma: float = 6.0) -> tuple[float, float]:
+    def sensitivity_analysis(
+        self,
+        gamma: float = 6.0,
+        outcome_proxies: list[float] | npt.NDArray[np.float64] | None = None,
+        proxy_mean: float | None = None,
+        alpha: float = 0.10,
+    ) -> tuple[float, float]:
         r"""Perform a sensitivity analysis.
 
         The analysis is separable across components. For coefficient c and component

--- a/pyrake/estimation/population.py
+++ b/pyrake/estimation/population.py
@@ -6,6 +6,8 @@ from typing import Any, Literal, Self
 
 import numpy as np
 import numpy.typing as npt
+from scipy import stats
+from scipy.optimize import linprog
 
 from .base_classes import Estimand, SimpleEstimand, WeightingEstimator
 from .sensitivity_solvers import LinearFractionalProgramSolver
@@ -370,7 +372,13 @@ class IPWEstimator(MeanEstimator):
         )
         return lb_var, ub_var
 
-    def sensitivity_analysis(self, gamma: float = 6.0) -> tuple[float, float]:
+    def sensitivity_analysis(
+        self,
+        gamma: float = 6.0,
+        outcome_proxies: list[float] | npt.NDArray[np.float64] | None = None,
+        proxy_mean: float | None = None,
+        alpha: float = 0.10,
+    ) -> tuple[float, float]:
         r"""Perform a sensitivity analysis.
 
         Calculate a range of point estimates implied by the Gamma factor.
@@ -380,6 +388,22 @@ class IPWEstimator(MeanEstimator):
          gamma : float, optional
             The Gamma factor. Must be >= 1.0, with 1.0 indicating perfect propensity
             scores. Defaults to 6. See Notes.
+         outcome_proxies : array_like, optional
+            A proxy for the outcome, observed for every unit in the sample. When
+            supplied together with ``proxy_mean``, an additional constraint is added
+            to the sensitivity region: the IPW estimate of the proxy mean must lie
+            within ``tol`` of ``proxy_mean``, where ``tol = z_crit * SE`` (the same
+            half-width as ``confidence_interval``). Weights that violate this
+            constraint are excluded from the sensitivity region, typically reducing
+            the width of the sensitivity interval. Must have the same length as
+            ``outcomes``. Requires ``proxy_mean`` to also be specified.
+         proxy_mean : float, optional
+            Known population mean of the outcome proxy. Requires ``outcome_proxies``
+            to also be specified.
+         alpha : float, optional
+            Significance level used to compute the proxy tolerance
+            ``tol = stats.norm.isf(alpha / 2) * sqrt(variance())``. Defaults to
+            0.10, matching the default of ``confidence_interval``.
 
         Returns
         -------
@@ -388,9 +412,11 @@ class IPWEstimator(MeanEstimator):
 
         Notes
         -----
-        See the Notes in WeightingEstimator for overall context. In our case, there is a
-        simple closed-form calculation for the sensitivity interval. See (Wilson 2025)
-        for details.
+        See the Notes in WeightingEstimator for overall context. Without an outcome
+        proxy there is a simple closed-form calculation for the sensitivity interval.
+        See (Wilson 2025) for details. When an outcome proxy is supplied, the
+        constrained optimisation is solved as a linear programme via
+        ``scipy.optimize.linprog``.
 
         References
         ----------
@@ -398,6 +424,11 @@ class IPWEstimator(MeanEstimator):
            Sampling." https://adventuresinwhy.com/post/survey_sampling/
 
         """
+        if (outcome_proxies is None) != (proxy_mean is None):
+            raise ValueError(
+                "`outcome_proxies` and `proxy_mean` must be provided together."
+            )
+
         if gamma < 1.0:
             raise ValueError("`gamma` must be >= 1")
 
@@ -405,12 +436,42 @@ class IPWEstimator(MeanEstimator):
             return self.point_estimate(), self.point_estimate()
 
         wl, wu = self.estimand.sensitivity_region(gamma)
-        lb = np.where(self.outcomes >= 0, wl, wu)
-        ub = np.where(self.outcomes >= 0, wu, wl)
-        return (
-            np.sum(self.outcomes * lb) / self.population_size,
-            np.sum(self.outcomes * ub) / self.population_size,
+
+        if outcome_proxies is None:
+            # Closed-form: element-wise weight selection.
+            lb = np.where(self.outcomes >= 0, wl, wu)
+            ub = np.where(self.outcomes >= 0, wu, wl)
+            return (
+                np.sum(self.outcomes * lb) / self.population_size,
+                np.sum(self.outcomes * ub) / self.population_size,
+            )
+
+        # LP formulation with proxy constraint.
+        p = np.asarray(outcome_proxies, dtype=float)
+        pm = float(proxy_mean)  # type: ignore[arg-type]
+        zcrit = stats.norm.isf(alpha / 2)
+        tol = zcrit * math.sqrt(self.variance())
+        N = self.population_size
+
+        # Proxy constraint: N*(pm - tol) <= p^T w <= N*(pm + tol)
+        A_ub = np.vstack([p, -p])
+        b_ub = np.array([N * (pm + tol), -N * (pm - tol)])
+        bounds = list(zip(wl.tolist(), wu.tolist(), strict=True))
+
+        lb_res = linprog(
+            c=self.outcomes, A_ub=A_ub, b_ub=b_ub, bounds=bounds, method="highs"
         )
+        ub_res = linprog(
+            c=-self.outcomes, A_ub=A_ub, b_ub=b_ub, bounds=bounds, method="highs"
+        )
+
+        if lb_res.status != 0 or ub_res.status != 0:
+            raise ValueError(
+                "Proxy constraints are infeasible: no weight vector in the "
+                "sensitivity region is consistent with the supplied proxy_mean."
+            )
+
+        return float(lb_res.fun) / N, float(-ub_res.fun) / N
 
 
 class AIPWEstimator(IPWEstimator):
@@ -515,7 +576,13 @@ class AIPWEstimator(IPWEstimator):
             / (len(self.weights) - 1)
         )
 
-    def sensitivity_analysis(self, gamma: float = 6.0) -> tuple[float, float]:
+    def sensitivity_analysis(
+        self,
+        gamma: float = 6.0,
+        outcome_proxies: list[float] | npt.NDArray[np.float64] | None = None,
+        proxy_mean: float | None = None,
+        alpha: float = 0.10,
+    ) -> tuple[float, float]:
         r"""Perform a sensitivity analysis.
 
         Calculate a range of point estimates implied by the Gamma factor.
@@ -525,6 +592,14 @@ class AIPWEstimator(IPWEstimator):
          gamma : float, optional
             The Gamma factor. Must be >= 1.0, with 1.0 indicating perfect propensity
             scores. Defaults to 6. See Notes.
+         outcome_proxies : array_like, optional
+            A proxy for the outcome with a known population mean. See
+            ``IPWEstimator.sensitivity_analysis`` for details. The proxy constraint
+            applies to the same (AIPW) weights.
+         proxy_mean : float, optional
+            Known population mean of the outcome proxy.
+         alpha : float, optional
+            Significance level for the proxy tolerance. Defaults to 0.10.
 
         Returns
         -------
@@ -549,7 +624,12 @@ class AIPWEstimator(IPWEstimator):
         if gamma == 1.0:
             return self.point_estimate(), self.point_estimate()
 
-        lb, ub = super().sensitivity_analysis(gamma=gamma)
+        lb, ub = super().sensitivity_analysis(
+            gamma=gamma,
+            outcome_proxies=outcome_proxies,
+            proxy_mean=proxy_mean,
+            alpha=alpha,
+        )
         return (
             self.mean_predicted_outcome + lb,
             self.mean_predicted_outcome + ub,
@@ -750,17 +830,41 @@ class SIPWEstimator(MeanEstimator):
         )
         return lb_var, ub_var
 
-    def sensitivity_analysis(self, gamma: float = 6.0) -> tuple[float, float]:
+    def sensitivity_analysis(
+        self,
+        gamma: float = 6.0,
+        outcome_proxies: list[float] | npt.NDArray[np.float64] | None = None,
+        proxy_mean: float | None = None,
+        alpha: float = 0.10,
+    ) -> tuple[float, float]:
         r"""Perform a sensitivity analysis.
 
         Calculate a range of point estimates implied by the Gamma factor.
-        See ``_sensitivity_weights`` for the algorithm.
+        See ``_sensitivity_weights`` for the unconstrained algorithm.
 
         Parameters
         ----------
          gamma : float, optional
             The Gamma factor. Must be >= 1.0, with 1.0 indicating perfect propensity
             scores. Defaults to 6. See Notes in WeightingEstimator.
+         outcome_proxies : array_like, optional
+            A proxy for the outcome with a known population mean. When supplied
+            together with ``proxy_mean``, an additional constraint is added to the
+            sensitivity region: the SIPW estimate of the proxy mean must lie within
+            ``tol`` of ``proxy_mean``, where ``tol = z_crit * SE``. For the SIPW
+            estimator this is ``(w^T proxy) / (w^T 1) in [pm - tol, pm + tol]``,
+            which is linear after the Charnes-Cooper transformation. Weights that
+            violate this constraint are excluded from the sensitivity region,
+            typically reducing the width of the sensitivity interval. Must have the
+            same length as ``outcomes``. Requires ``proxy_mean`` to also be
+            specified.
+         proxy_mean : float, optional
+            Known population mean of the outcome proxy. Requires ``outcome_proxies``
+            to also be specified.
+         alpha : float, optional
+            Significance level for the proxy tolerance
+            ``tol = stats.norm.isf(alpha / 2) * sqrt(variance())``. Defaults to
+            0.10, matching the default of ``confidence_interval``.
 
         Returns
         -------
@@ -768,17 +872,82 @@ class SIPWEstimator(MeanEstimator):
             Lower and upper bounds on the point estimate.
 
         """
+        if (outcome_proxies is None) != (proxy_mean is None):
+            raise ValueError(
+                "`outcome_proxies` and `proxy_mean` must be provided together."
+            )
+
         if gamma < 1.0:
             raise ValueError("`gamma` must be >= 1")
 
         if gamma == 1.0:
             return self.point_estimate(), self.point_estimate()
 
-        lb_weights, ub_weights = self._sensitivity_weights(gamma)
-        return (
-            np.dot(self.outcomes, lb_weights) / np.sum(lb_weights),
-            np.dot(self.outcomes, ub_weights) / np.sum(ub_weights),
+        if outcome_proxies is None:
+            lb_weights, ub_weights = self._sensitivity_weights(gamma)
+            return (
+                np.dot(self.outcomes, lb_weights) / np.sum(lb_weights),
+                np.dot(self.outcomes, ub_weights) / np.sum(ub_weights),
+            )
+
+        # Charnes-Cooper LP with proxy constraint.
+        wl, wu = self.estimand.sensitivity_region(gamma)
+        p = np.asarray(outcome_proxies, dtype=float)
+        pm = float(proxy_mean)  # type: ignore[arg-type]
+        zcrit = stats.norm.isf(alpha / 2)
+        tol = zcrit * math.sqrt(self.variance())
+        n = len(self.outcomes)
+
+        # Variables: x = [w_cc (n), s (1)]
+        # Objective: outcomes^T w_cc  (s has zero coefficient)
+        c_obj = np.append(self.outcomes, 0.0)
+
+        # Equality: sum(w_cc) = 1  →  [ones; 0] @ x = 1
+        A_eq = np.append(np.ones(n), 0.0).reshape(1, n + 1)
+        b_eq = np.array([1.0])
+
+        # Box inequalities: -w_cc + wl*s <= 0,  w_cc - wu*s <= 0
+        top = np.hstack([-np.eye(n), wl.reshape(-1, 1)])
+        bottom = np.hstack([np.eye(n), -wu.reshape(-1, 1)])
+
+        # Proxy constraints (after CC substitution; valid since sum(w_cc)=1):
+        # p^T w_cc <= pm + tol  →  (p - (pm+tol))^T w_cc <= 0
+        # p^T w_cc >= pm - tol  →  ((pm-tol) - p)^T w_cc <= 0
+        proxy_upper = np.append(p - (pm + tol), 0.0).reshape(1, n + 1)
+        proxy_lower = np.append((pm - tol) - p, 0.0).reshape(1, n + 1)
+
+        A_ub = np.vstack([top, bottom, proxy_upper, proxy_lower])
+        b_ub = np.zeros(2 * n + 2)
+
+        # Bounds: w_cc unconstrained (enforced by A_ub), s >= 0
+        bounds = [(-np.inf, np.inf)] * n + [(0.0, np.inf)]
+
+        lb_res = linprog(
+            c=c_obj,
+            A_ub=A_ub,
+            b_ub=b_ub,
+            A_eq=A_eq,
+            b_eq=b_eq,
+            bounds=bounds,
+            method="highs",
         )
+        ub_res = linprog(
+            c=-c_obj,
+            A_ub=A_ub,
+            b_ub=b_ub,
+            A_eq=A_eq,
+            b_eq=b_eq,
+            bounds=bounds,
+            method="highs",
+        )
+
+        if lb_res.status != 0 or ub_res.status != 0:
+            raise ValueError(
+                "Proxy constraints are infeasible: no weight vector in the "
+                "sensitivity region is consistent with the supplied proxy_mean."
+            )
+
+        return float(lb_res.fun), float(-ub_res.fun)
 
 
 class SAIPWEstimator(SIPWEstimator):
@@ -857,7 +1026,13 @@ class SAIPWEstimator(SIPWEstimator):
             * np.square(self.outcomes - super().point_estimate())
         ) / (np.sum(self.weights) ** 2)
 
-    def sensitivity_analysis(self, gamma: float = 6.0) -> tuple[float, float]:
+    def sensitivity_analysis(
+        self,
+        gamma: float = 6.0,
+        outcome_proxies: list[float] | npt.NDArray[np.float64] | None = None,
+        proxy_mean: float | None = None,
+        alpha: float = 0.10,
+    ) -> tuple[float, float]:
         r"""Perform a sensitivity analysis.
 
         Calculate a range of point estimates implied by the Gamma factor.
@@ -867,6 +1042,14 @@ class SAIPWEstimator(SIPWEstimator):
          gamma : float, optional
             The Gamma factor. Must be >= 1.0, with 1.0 indicating perfect propensity
             scores. Defaults to 6. See Notes.
+         outcome_proxies : array_like, optional
+            A proxy for the outcome with a known population mean. See
+            ``SIPWEstimator.sensitivity_analysis`` for details. The proxy constraint
+            applies to the same (SAIPW) weights.
+         proxy_mean : float, optional
+            Known population mean of the outcome proxy.
+         alpha : float, optional
+            Significance level for the proxy tolerance. Defaults to 0.10.
 
         Returns
         -------
@@ -884,7 +1067,12 @@ class SAIPWEstimator(SIPWEstimator):
         if gamma == 1.0:
             return self.point_estimate(), self.point_estimate()
 
-        lb, ub = super().sensitivity_analysis(gamma=gamma)
+        lb, ub = super().sensitivity_analysis(
+            gamma=gamma,
+            outcome_proxies=outcome_proxies,
+            proxy_mean=proxy_mean,
+            alpha=alpha,
+        )
         return (
             self.mean_predicted_outcome + lb,
             self.mean_predicted_outcome + ub,
@@ -1016,7 +1204,13 @@ class RatioEstimator(WeightingEstimator):
             ),
         )
 
-    def sensitivity_analysis(self, gamma: float = 6.0) -> tuple[float, float]:
+    def sensitivity_analysis(
+        self,
+        gamma: float = 6.0,
+        outcome_proxies: list[float] | npt.NDArray[np.float64] | None = None,
+        proxy_mean: float | None = None,
+        alpha: float = 0.10,
+    ) -> tuple[float, float]:
         r"""Perform a sensitivity analysis.
 
         Calculate a range of point estimates implied by the Gamma factor.

--- a/pyrake/estimation/treatment_effects.py
+++ b/pyrake/estimation/treatment_effects.py
@@ -213,7 +213,14 @@ class TreatmentEffectEstimator(WeightingEstimator):
         """
         return super().confidence_interval(alpha=alpha, alternative=alternative)
 
-    def sensitivity_analysis(self, gamma: float = 6.0) -> tuple[float, float]:
+    def sensitivity_analysis(  # type: ignore[override]
+        self,
+        gamma: float = 6.0,
+        control_outcome_proxies: list[float] | npt.NDArray[np.float64] | None = None,
+        treated_outcome_proxies: list[float] | npt.NDArray[np.float64] | None = None,
+        proxy_mean: float | None = None,
+        alpha: float = 0.10,
+    ) -> tuple[float, float]:
         r"""Perform a sensitivity analysis.
 
         Calculate a range of point estimates implied by the Gamma factor.
@@ -223,6 +230,24 @@ class TreatmentEffectEstimator(WeightingEstimator):
          gamma : float, optional
             The Gamma factor. Must be >= 1.0, with 1.0 indicating perfect propensity
             scores. Defaults to 6. See Notes.
+         control_outcome_proxies : array_like, optional
+            A proxy for the outcome observed for every control-group unit, with a
+            known population mean given by ``proxy_mean``. When supplied (together
+            with ``treated_outcome_proxies`` and ``proxy_mean``), a constraint is
+            added to the control-arm sensitivity region requiring the weighted
+            proxy estimate to be within the estimator's confidence-interval
+            half-width of ``proxy_mean``. Must have the same length as the
+            control-group outcomes. All three of ``control_outcome_proxies``,
+            ``treated_outcome_proxies``, and ``proxy_mean`` must be provided
+            together.
+         treated_outcome_proxies : array_like, optional
+            A proxy for the outcome observed for every treated-group unit. See
+            ``control_outcome_proxies`` for details.
+         proxy_mean : float, optional
+            Known population mean of the outcome proxy. Required when either
+            ``control_outcome_proxies`` or ``treated_outcome_proxies`` is supplied.
+         alpha : float, optional
+            Significance level for the proxy tolerance. Defaults to 0.10.
 
         Returns
         -------
@@ -237,10 +262,16 @@ class TreatmentEffectEstimator(WeightingEstimator):
 
         """
         control_lb, control_ub = self.control_estimator.sensitivity_analysis(
-            gamma=gamma
+            gamma=gamma,
+            outcome_proxies=control_outcome_proxies,
+            proxy_mean=proxy_mean,
+            alpha=alpha,
         )
         treated_lb, treated_ub = self.treated_estimator.sensitivity_analysis(
-            gamma=gamma
+            gamma=gamma,
+            outcome_proxies=treated_outcome_proxies,
+            proxy_mean=proxy_mean,
+            alpha=alpha,
         )
 
         return treated_lb - control_ub, treated_ub - control_lb
@@ -1163,7 +1194,13 @@ class TreatmentEffectRatioEstimator(WeightingEstimator):
             - (2.0 * mu_num / (mu_den**3.0)) * cov_num_den
         )
 
-    def sensitivity_analysis(self, gamma: float = 6.0) -> tuple[float, float]:
+    def sensitivity_analysis(
+        self,
+        gamma: float = 6.0,
+        outcome_proxies: list[float] | npt.NDArray[np.float64] | None = None,
+        proxy_mean: float | None = None,
+        alpha: float = 0.10,
+    ) -> tuple[float, float]:
         """Not implemented."""
         raise NotImplementedError(
             "Sensitivity analysis is not implemented for TreatmentEffectRatioEstimator."

--- a/test/estimation/test_population.py
+++ b/test/estimation/test_population.py
@@ -1577,3 +1577,200 @@ class TestRatioEstimator:
         assert set(df.columns) == set(expected_columns)
         assert len(df) == 50
         plt.close("all")
+
+
+class TestOutcomeProxySensitivity:
+    """Tests for outcome-proxy-constrained sensitivity analysis."""
+
+    @staticmethod
+    def _make_proxy(
+        outcomes: npt.NDArray[np.float64],
+        seed: int = 7,
+        noise_scale: float = 0.05,
+    ) -> tuple[npt.NDArray[np.float64], float]:
+        """Return (proxy, proxy_mean) where proxy = outcome + small noise."""
+        rng = np.random.default_rng(seed)
+        proxies = outcomes + noise_scale * rng.standard_normal(len(outcomes))
+        # Use the sample mean as a stand-in for the known population mean.
+        proxy_mean = float(np.mean(proxies))
+        return proxies, proxy_mean
+
+    # ------------------------------------------------------------------
+    # IPWEstimator
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def test_ipw_proxy_tightens_interval() -> None:
+        """Proxy-constrained IPW interval is contained in the unconstrained one."""
+        population_size, propensities, outcomes = TestIPWEstimator.get_data(
+            binary=False
+        )
+        estimator = IPWEstimator(
+            propensities, outcomes, population_size, estimand_class=PopulationMean
+        )
+        gamma = 4.0
+        proxies, proxy_mean = TestOutcomeProxySensitivity._make_proxy(outcomes)
+
+        lb0, ub0 = estimator.sensitivity_analysis(gamma=gamma)
+        lb1, ub1 = estimator.sensitivity_analysis(
+            gamma=gamma, outcome_proxies=proxies, proxy_mean=proxy_mean
+        )
+
+        # Proxy interval must be a subset of the unconstrained interval.
+        assert lb1 >= lb0 - 1e-10
+        assert ub1 <= ub0 + 1e-10
+        # And strictly narrower (proxy is highly correlated with outcomes).
+        assert ub1 - lb1 < ub0 - lb0
+
+    @staticmethod
+    def test_ipw_proxy_gamma_one() -> None:
+        """gamma=1 returns the point estimate regardless of proxy."""
+        population_size, propensities, outcomes = TestIPWEstimator.get_data(
+            binary=False
+        )
+        estimator = IPWEstimator(
+            propensities, outcomes, population_size, estimand_class=PopulationMean
+        )
+        proxies, proxy_mean = TestOutcomeProxySensitivity._make_proxy(outcomes)
+        lb, ub = estimator.sensitivity_analysis(
+            gamma=1.0, outcome_proxies=proxies, proxy_mean=proxy_mean
+        )
+        pe = estimator.point_estimate()
+        assert lb == pytest.approx(pe)
+        assert ub == pytest.approx(pe)
+
+    @staticmethod
+    def test_ipw_proxy_missing_proxy_mean_raises() -> None:
+        """Providing outcome_proxies without proxy_mean raises ValueError."""
+        population_size, propensities, outcomes = TestIPWEstimator.get_data(
+            binary=False
+        )
+        estimator = IPWEstimator(
+            propensities, outcomes, population_size, estimand_class=PopulationMean
+        )
+        proxies, _ = TestOutcomeProxySensitivity._make_proxy(outcomes)
+        with pytest.raises(ValueError, match="proxy_mean"):
+            estimator.sensitivity_analysis(gamma=4.0, outcome_proxies=proxies)
+
+    # ------------------------------------------------------------------
+    # AIPWEstimator
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def test_aipw_proxy_tightens_interval() -> None:
+        """Proxy-constrained AIPW interval is contained in the unconstrained one."""
+        (
+            population_size,
+            propensities,
+            outcomes,
+            predicted_outcomes,
+            mean_predicted_outcome,
+        ) = TestAIPWEstimator.get_data(binary=False)
+        estimator = AIPWEstimator(
+            propensities,
+            outcomes,
+            predicted_outcomes,
+            mean_predicted_outcome,
+            population_size,
+        )
+        gamma = 4.0
+        proxies, proxy_mean = TestOutcomeProxySensitivity._make_proxy(outcomes)
+
+        lb0, ub0 = estimator.sensitivity_analysis(gamma=gamma)
+        lb1, ub1 = estimator.sensitivity_analysis(
+            gamma=gamma, outcome_proxies=proxies, proxy_mean=proxy_mean
+        )
+
+        assert lb1 >= lb0 - 1e-10
+        assert ub1 <= ub0 + 1e-10
+        assert ub1 - lb1 < ub0 - lb0
+
+    # ------------------------------------------------------------------
+    # SIPWEstimator
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def test_sipw_proxy_tightens_interval_binary() -> None:
+        """Proxy-constrained SIPW interval is contained in the unconstrained one (binary)."""
+        propensities, outcomes = TestSIPWEstimator.get_data(binary=True)
+        estimator = SIPWEstimator(propensities, outcomes)
+        gamma = 4.0
+        proxies, proxy_mean = TestOutcomeProxySensitivity._make_proxy(
+            outcomes, noise_scale=0.02
+        )
+
+        lb0, ub0 = estimator.sensitivity_analysis(gamma=gamma)
+        lb1, ub1 = estimator.sensitivity_analysis(
+            gamma=gamma, outcome_proxies=proxies, proxy_mean=proxy_mean
+        )
+
+        assert lb1 >= lb0 - 1e-10
+        assert ub1 <= ub0 + 1e-10
+        assert ub1 - lb1 < ub0 - lb0
+
+    @staticmethod
+    def test_sipw_proxy_tightens_interval_continuous() -> None:
+        """Proxy-constrained SIPW interval is contained in the unconstrained one (continuous)."""
+        propensities, outcomes = TestSIPWEstimator.get_data(binary=False)
+        estimator = SIPWEstimator(propensities, outcomes)
+        gamma = 4.0
+        proxies, proxy_mean = TestOutcomeProxySensitivity._make_proxy(outcomes)
+
+        lb0, ub0 = estimator.sensitivity_analysis(gamma=gamma)
+        lb1, ub1 = estimator.sensitivity_analysis(
+            gamma=gamma, outcome_proxies=proxies, proxy_mean=proxy_mean
+        )
+
+        assert lb1 >= lb0 - 1e-10
+        assert ub1 <= ub0 + 1e-10
+        assert ub1 - lb1 < ub0 - lb0
+
+    @staticmethod
+    def test_sipw_proxy_gamma_one() -> None:
+        """gamma=1 returns the point estimate regardless of proxy."""
+        propensities, outcomes = TestSIPWEstimator.get_data(binary=False)
+        estimator = SIPWEstimator(propensities, outcomes)
+        proxies, proxy_mean = TestOutcomeProxySensitivity._make_proxy(outcomes)
+        lb, ub = estimator.sensitivity_analysis(
+            gamma=1.0, outcome_proxies=proxies, proxy_mean=proxy_mean
+        )
+        pe = estimator.point_estimate()
+        assert lb == pytest.approx(pe)
+        assert ub == pytest.approx(pe)
+
+    @staticmethod
+    def test_sipw_proxy_missing_proxy_mean_raises() -> None:
+        """Providing outcome_proxies without proxy_mean raises ValueError."""
+        propensities, outcomes = TestSIPWEstimator.get_data(binary=False)
+        estimator = SIPWEstimator(propensities, outcomes)
+        proxies, _ = TestOutcomeProxySensitivity._make_proxy(outcomes)
+        with pytest.raises(ValueError, match="proxy_mean"):
+            estimator.sensitivity_analysis(gamma=4.0, outcome_proxies=proxies)
+
+    # ------------------------------------------------------------------
+    # SAIPWEstimator
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def test_saipw_proxy_tightens_interval() -> None:
+        """Proxy-constrained SAIPW interval is contained in the unconstrained one."""
+        (
+            propensities,
+            outcomes,
+            predicted_outcomes,
+            mean_predicted_outcome,
+        ) = TestSAIPWEstimator.get_data(binary=False)
+        estimator = SAIPWEstimator(
+            propensities, outcomes, predicted_outcomes, mean_predicted_outcome
+        )
+        gamma = 4.0
+        proxies, proxy_mean = TestOutcomeProxySensitivity._make_proxy(outcomes)
+
+        lb0, ub0 = estimator.sensitivity_analysis(gamma=gamma)
+        lb1, ub1 = estimator.sensitivity_analysis(
+            gamma=gamma, outcome_proxies=proxies, proxy_mean=proxy_mean
+        )
+
+        assert lb1 >= lb0 - 1e-10
+        assert ub1 <= ub0 + 1e-10
+        assert ub1 - lb1 < ub0 - lb0

--- a/test/estimation/test_treatment_effects.py
+++ b/test/estimation/test_treatment_effects.py
@@ -1541,3 +1541,119 @@ class TestTreatmentEffectRatioEstimator:
         lower, upper = estimator.confidence_interval(alpha=0.05, alternative="less")
         assert upper == pytest.approx(pe + z * se, rel=1e-12)
         assert lower == -np.inf
+
+
+class TestOutcomeProxyTreatmentEffect:
+    """Tests for outcome-proxy-constrained sensitivity analysis in treatment-effect estimators."""
+
+    @staticmethod
+    def _make_proxies(
+        control_outcomes: npt.NDArray[np.float64],
+        treated_outcomes: npt.NDArray[np.float64],
+        seed: int = 11,
+        noise_scale: float = 0.05,
+    ) -> tuple[
+        npt.NDArray[np.float64],
+        npt.NDArray[np.float64],
+        float,
+    ]:
+        """Return (control_proxies, treated_proxies, proxy_mean)."""
+        rng = np.random.default_rng(seed)
+        ctrl_proxies = control_outcomes + noise_scale * rng.standard_normal(
+            len(control_outcomes)
+        )
+        trt_proxies = treated_outcomes + noise_scale * rng.standard_normal(
+            len(treated_outcomes)
+        )
+        all_proxies = np.concatenate([ctrl_proxies, trt_proxies])
+        proxy_mean = float(np.mean(all_proxies))
+        return ctrl_proxies, trt_proxies, proxy_mean
+
+    @staticmethod
+    def test_treatment_effect_proxy_tightens_interval() -> None:
+        """Proxy-constrained TreatmentEffectEstimator interval is contained in unconstrained."""
+        (
+            control_propensities,
+            control_outcomes,
+            _,
+            _,
+            _,
+            treated_propensities,
+            treated_outcomes,
+            _,
+            _,
+            _,
+        ) = TestATEEstimator.get_data()
+
+        estimator = TreatmentEffectEstimator(
+            control_estimator=SIPWEstimator(
+                propensity_scores=control_propensities,
+                outcomes=control_outcomes,
+            ),
+            treated_estimator=SIPWEstimator(
+                propensity_scores=treated_propensities,
+                outcomes=treated_outcomes,
+            ),
+        )
+
+        gamma = 3.0
+        ctrl_proxies, trt_proxies, proxy_mean = (
+            TestOutcomeProxyTreatmentEffect._make_proxies(
+                control_outcomes, treated_outcomes
+            )
+        )
+
+        lb0, ub0 = estimator.sensitivity_analysis(gamma=gamma)
+        lb1, ub1 = estimator.sensitivity_analysis(
+            gamma=gamma,
+            control_outcome_proxies=ctrl_proxies,
+            treated_outcome_proxies=trt_proxies,
+            proxy_mean=proxy_mean,
+        )
+
+        # Constrained interval is a subset of unconstrained.
+        assert lb1 >= lb0 - 1e-10
+        assert ub1 <= ub0 + 1e-10
+        assert ub1 - lb1 < ub0 - lb0
+
+    @staticmethod
+    def test_treatment_effect_proxy_gamma_one() -> None:
+        """gamma=1 returns point estimate regardless of proxy."""
+        (
+            control_propensities,
+            control_outcomes,
+            _,
+            _,
+            _,
+            treated_propensities,
+            treated_outcomes,
+            _,
+            _,
+            _,
+        ) = TestATEEstimator.get_data()
+
+        estimator = TreatmentEffectEstimator(
+            control_estimator=SIPWEstimator(
+                propensity_scores=control_propensities,
+                outcomes=control_outcomes,
+            ),
+            treated_estimator=SIPWEstimator(
+                propensity_scores=treated_propensities,
+                outcomes=treated_outcomes,
+            ),
+        )
+        ctrl_proxies, trt_proxies, proxy_mean = (
+            TestOutcomeProxyTreatmentEffect._make_proxies(
+                control_outcomes, treated_outcomes
+            )
+        )
+
+        lb, ub = estimator.sensitivity_analysis(
+            gamma=1.0,
+            control_outcome_proxies=ctrl_proxies,
+            treated_outcome_proxies=trt_proxies,
+            proxy_mean=proxy_mean,
+        )
+        pe = estimator.point_estimate()
+        assert lb == pytest.approx(pe, rel=1e-6)
+        assert ub == pytest.approx(pe, rel=1e-6)


### PR DESCRIPTION
Sensitivity analysis methods now accept an optional outcome proxy —
a variable observed for every sample unit whose population mean is
known. When supplied, the optimisation problem is constrained so that
the weighted proxy mean lies within z_crit × SE of the known
population mean, where z_crit and SE match the existing
confidence_interval method defaults (alpha=0.10).

Changes:
- IPWEstimator.sensitivity_analysis: closed-form path unchanged;
  proxy path solves a box-constrained LP via scipy.optimize.linprog.
- AIPWEstimator.sensitivity_analysis: passes proxy params to the
  IPW super call and re-adds mean_predicted_outcome.
- SIPWEstimator.sensitivity_analysis: greedy path unchanged; proxy
  path solves a Charnes-Cooper LP with additional proxy constraints.
- SAIPWEstimator.sensitivity_analysis: mirrors AIPW over SIPW.
- TreatmentEffectEstimator.sensitivity_analysis: accepts separate
  control_outcome_proxies and treated_outcome_proxies that are
  forwarded to the respective arm estimators.
- WeightingEstimator abstract method and RatioEstimator,
  LinearCombinationEstimator updated to carry consistent signatures.
- 11 new tests covering all four estimator classes plus
  TreatmentEffectEstimator; tests verify interval containment,
  gamma=1 identity, and missing-parameter validation.

https://claude.ai/code/session_01Jt9LLcJuzzJDphdvnZGjGb